### PR TITLE
Start Server with Backend Clojure Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Web Tic Tac Toe
+This web version of Tic Tac Toe is currently under construction.
+
+## Dependencies 
+* [Clojure](https://clojure.org/guides/getting_started) 1.8.0 
+* [Java](http://www.oracle.com/technetwork/java/javase/downloads/jre10-downloads-4417026.html) 10.0.1 
+* [Leiningen](https://leiningen.org) 2.8.1 
+
+## Starting the Server
+To start the Server on default port 8888, run the following command from the root directory: 
+```lein run```

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,13 @@
   :url "https://github.com/omarnyte/Web-Tic-Tac-Toe"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[info.cukes/cucumber-java "1.2.4"]
+                 [info.cukes/cucumber-junit "1.2.4"]
+                 [junit/junit "4.12"]
+                 [org.json/json "20180813"]
+                 [org.clojure/clojure "1.8.0"]
                  [org.clojure/math.numeric-tower "0.0.4"]]
   :main ^:skip-aot web-tic-tac-toe.core
   :target-path "target/%s"
-  :profiles {:uberjar {:aot :all}})
+  :profiles {:uberjar {:aot :all}}
+  :java-source-paths ["http-server"])

--- a/src/web_tic_tac_toe/core.clj
+++ b/src/web_tic_tac_toe/core.clj
@@ -1,33 +1,34 @@
 (ns web-tic-tac-toe.core
-  (:require [web-tic-tac-toe.default-handler])
+  (:require [web-tic-tac-toe.default-handler :as default-handler]
+            [web-tic-tac-toe.middleware :as middleware])
   (:gen-class))
 
-; (import Router Middleware Server)
+(import Directory Router Server)
 
-; (defn get-default-handler
-;   []
-;   default-handler)
+(def default-port 8888)
+(def path (System/getProperty "user.dir"))
 
-; (defn get-routes
-;   []
-;   (doto (new java.util.HashMap)))
+(defn get-routes
+  []
+  (doto (new java.util.HashMap)))
 
-; (defn get-directory
-;   []
-;   (doto (new java.util.HashMap)))
+(defn get-directory
+  []
+  (Directory. path))
 
-; (defn setUpRouter 
-;   []
-;   (Router. (get-default-handler) (get-routes) (get-directory)))
+(defn set-up-router 
+  []
+  (Router. (default-handler/reify-handler)
+           (get-routes) 
+           (get-directory)))
 
-; (defn startServer
-;   []
-;   (Server. 5000 (setUpRouter) (setUpMiddlewareChain))))
-
-; (defn -main
-;   []
-;   startServer)
+(defn configure-server
+  []
+  (Server. default-port 
+           (set-up-router) 
+           (middleware/extend-middleware)))
 
 (defn -main
   []
-  (println "Hello, web!"))
+  (.. (configure-server)
+      (start)))

--- a/src/web_tic_tac_toe/core.clj
+++ b/src/web_tic_tac_toe/core.clj
@@ -1,6 +1,33 @@
 (ns web-tic-tac-toe.core
+  (:require [web-tic-tac-toe.default-handler])
   (:gen-class))
+
+; (import Router Middleware Server)
+
+; (defn get-default-handler
+;   []
+;   default-handler)
+
+; (defn get-routes
+;   []
+;   (doto (new java.util.HashMap)))
+
+; (defn get-directory
+;   []
+;   (doto (new java.util.HashMap)))
+
+; (defn setUpRouter 
+;   []
+;   (Router. (get-default-handler) (get-routes) (get-directory)))
+
+; (defn startServer
+;   []
+;   (Server. 5000 (setUpRouter) (setUpMiddlewareChain))))
+
+; (defn -main
+;   []
+;   startServer)
 
 (defn -main
   []
-  (println "Welcome to Web Tic Tac Toe!"))
+  (println "Hello, web!"))

--- a/src/web_tic_tac_toe/default_handler.clj
+++ b/src/web_tic_tac_toe/default_handler.clj
@@ -1,0 +1,19 @@
+(ns web-tic-tac-toe.default-handler
+  (:gen-class))
+
+(import Handler HttpStatusCode)
+
+(defn- build-response
+  []
+  (.. (Response$Builder. HttpStatusCode/OK)
+      (messageBody "Hello, world!")
+      (build)))
+
+(defn- generate-response 
+  [request]
+  (build-response))
+
+(defn reify-handler 
+  []
+  (reify Handler 
+    (generateResponse [this request] (generate-response request))))

--- a/src/web_tic_tac_toe/middleware.clj
+++ b/src/web_tic_tac_toe/middleware.clj
@@ -1,0 +1,13 @@
+(ns web-tic-tac-toe.middleware
+  (:gen-class))
+
+(import Middleware)
+
+(defn- apply-middleware
+  [response]
+  response)
+
+(defn extend-middleware
+  []
+  (proxy [Middleware] []
+    (applyMiddleware [response] (apply-middleware response))))

--- a/test/web_tic_tac_toe/default_handler_test.clj
+++ b/test/web_tic_tac_toe/default_handler_test.clj
@@ -1,0 +1,22 @@
+(ns web-tic-tac-toe.default-handler-test
+  (:require [clojure.test :refer :all]
+            [web-tic-tac-toe.default-handler :refer :all]))
+
+(import Handler HttpStatusCode Request Response)
+
+(def sample-request
+     (.. (Request$Builder.)
+         (build)))
+
+(def handler reify-handler)
+    
+(def response-from-handler
+  (.generateResponse (handler) sample-request))
+
+(deftest generate-response-test 
+  (testing "it builds a Response with status code 200")
+    (is (= HttpStatusCode/OK 
+           (.getStatusCode response-from-handler)))
+  (testing "it builds a Response with message body 'Hello, world!")
+    (is (= "Hello, world!"
+        (String. (.getMessageBody response-from-handler)))))

--- a/test/web_tic_tac_toe/middleware_test.clj
+++ b/test/web_tic_tac_toe/middleware_test.clj
@@ -1,0 +1,26 @@
+(ns web-tic-tac-toe.middleware-test
+  (:require [clojure.test :refer :all]
+            [web-tic-tac-toe.middleware :refer :all]))
+
+(import HttpStatusCode Middleware Response)
+
+(def message-body "Hello, world!")
+
+(def pre-middleware-response
+     (.. (Response$Builder. HttpStatusCode/OK)
+         (messageBody "Hello, world!")
+         (build)))
+
+(def middleware extend-middleware)
+
+(def post-middleware-response 
+     (.applyMiddleware (middleware) pre-middleware-response))
+
+(deftest apply-middleware-test 
+  (testing "it does not alter the status code")
+    (is (= HttpStatusCode/OK
+           (.getStatusCode post-middleware-response)))
+  (testing "it does not alter the message body")
+    (is (= message-body
+           (String. (.getMessageBody post-middleware-response)))))
+                


### PR DESCRIPTION
## `project.clj`
Because of the way that I've copied the server source code into this repository, I manually installed the server dependencies inside of this file. I also pointed `java-source-paths` to the nested server source code. When I eventually push the server up as a dependency through Maven, I will remove these dependencies, as they will then be provided through the server installation.  

## Core 
Because the aim of this PR was to simply configure and start the server, it does not include any Tic Tac Toe configurations. 

## Default-Handler  
In order to implement the`Handler` interface, this namespace  `reify`s the Java `#generateResponse(Request request)` method as `(def generate-response [request])`.  As a test, this handler simply returns a 200 OK "Hello, world!" `Response` object. 

## Middleware
Because `reify` can only support interfaces and protocols, this namespace extends the `Middleware` class via a `proxy`. It overrides the Java `#applyMiddleware(Response response)` method with `(def apply-middleware [response])`. Again, as a test, it simply returns an unaltered `Response` object.  


