### PR TITLE
Install and import http-server as dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,13 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[cheshire "5.8.0"]
-                 [info.cukes/cucumber-java "1.2.4"]
-                 [info.cukes/cucumber-junit "1.2.4"]
-                 [junit/junit "4.12"]
-                 [org.json/json "20180813"]
+                 [com.omarnyte/http-server "1.0-SNAPSHOT"]
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/math.numeric-tower "0.0.4"]]
   :main ^:skip-aot web-tic-tac-toe.core
   :target-path "target/%s"
-  :profiles {:uberjar {:aot :all}}
-  :java-source-paths ["http-server"])
+  :profiles {:uberjar {:aot :all}})

--- a/src/web_tic_tac_toe/core.clj
+++ b/src/web_tic_tac_toe/core.clj
@@ -5,7 +5,9 @@
             [web-tic-tac-toe.middleware :as middleware])
   (:gen-class))
 
-(import Directory Middleware Router Server)
+(import (com.omarnyte Directory Router Server)
+        (com.omarnyte.logger Logger)
+        (com.omarnyte.middleware Middleware))
 
 (def default-port 8888)
 (def path (str (System/getProperty "user.dir") "/public"))

--- a/src/web_tic_tac_toe/default_handler.clj
+++ b/src/web_tic_tac_toe/default_handler.clj
@@ -1,7 +1,9 @@
 (ns web-tic-tac-toe.default-handler
   (:gen-class))
 
-(import Handler HttpStatusCode MessageHeader)
+(import (com.omarnyte.handler Handler) 
+        (com.omarnyte.http MessageHeader)
+        (com.omarnyte.response HttpStatusCode Response$Builder))
 
 (defn- build-response
   [directory]

--- a/src/web_tic_tac_toe/game_state.clj
+++ b/src/web_tic_tac_toe/game_state.clj
@@ -5,7 +5,7 @@
             [tic-tac-clojure.game-logic :as game-logic]
             [tic-tac-clojure.player :as player]))
 
-(import BadRequestException)
+(import (com.omarnyte.exception BadRequestException))
 
 (def missingSelectedIdxMessage "selectedIdx is required")
 (def invalidSelectedIdxMessage "Index selection is invalid")

--- a/src/web_tic_tac_toe/middleware.clj
+++ b/src/web_tic_tac_toe/middleware.clj
@@ -1,7 +1,7 @@
 (ns web-tic-tac-toe.middleware
   (:gen-class))
 
-(import Middleware)
+(import (com.omarnyte.middleware Middleware))
 
 (defn- apply-middleware
   [response]

--- a/src/web_tic_tac_toe/move_handler.clj
+++ b/src/web_tic_tac_toe/move_handler.clj
@@ -3,7 +3,10 @@
   (:require [cheshire.core :as cheshire]
             [web-tic-tac-toe.game-state :as game-state]))
 
-(import Handler MessageHeader Response)
+(import (com.omarnyte.exception BadRequestException)
+        (com.omarnyte.handler Handler)
+        (com.omarnyte.http MessageHeader)
+        (com.omarnyte.response HttpStatusCode Response$Builder))
 
 (def get-keywords-back true)
 

--- a/src/web_tic_tac_toe/new_game_handler.clj
+++ b/src/web_tic_tac_toe/new_game_handler.clj
@@ -4,7 +4,9 @@
             [clojure.string :as str]
             [tic-tac-clojure.board :as board]))
 
-(import Handler Response)
+(import (com.omarnyte.handler Handler)
+        (com.omarnyte.http MessageHeader) 
+        (com.omarnyte.response HttpStatusCode Response Response$Builder))
 
 (def first-player-mark "X")
 (def game-type-separator #"\-v\-")

--- a/test/web_tic_tac_toe/default_handler_test.clj
+++ b/test/web_tic_tac_toe/default_handler_test.clj
@@ -2,7 +2,10 @@
   (:require [clojure.test :refer :all]
             [web-tic-tac-toe.default-handler :refer :all]))
 
-(import HttpStatusCode MessageHeader)
+(import (com.omarnyte Directory) 
+        (com.omarnyte.http MessageHeader) 
+        (com.omarnyte.request Request$Builder)
+        (com.omarnyte.response HttpStatusCode))
 
 (def sample-request
      (.. (Request$Builder.)

--- a/test/web_tic_tac_toe/game_state_test.clj
+++ b/test/web_tic_tac_toe/game_state_test.clj
@@ -3,6 +3,8 @@
             [tic-tac-clojure.sample-boards :as sample-boards]
             [web-tic-tac-toe.game-state :refer :all]))
 
+(import (com.omarnyte.exception BadRequestException))
+          
 (def no-idx-game-state 
   {:board ["X" nil nil nil nil nil nil nil nil]
    :players {:currentPlayerMark "O"

--- a/test/web_tic_tac_toe/middleware_test.clj
+++ b/test/web_tic_tac_toe/middleware_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer :all]
             [web-tic-tac-toe.middleware :refer :all]))
 
-(import HttpStatusCode Middleware Response)
+(import (com.omarnyte.middleware Middleware) 
+        (com.omarnyte.response HttpStatusCode Response$Builder))
 
 (def message-body "Hello, world!")
 

--- a/test/web_tic_tac_toe/move_handler_test.clj
+++ b/test/web_tic_tac_toe/move_handler_test.clj
@@ -3,7 +3,9 @@
             [clojure.test :refer :all]
             [tic-tac-clojure.sample-boards :as sample-boards]
             [web-tic-tac-toe.move-handler :refer :all]))
-     
+
+(import (com.omarnyte.request Request$Builder))            
+
 (def board [nil nil nil nil nil nil nil nil nil])
           
 (def move-handler (reify-handler))

--- a/test/web_tic_tac_toe/new_game_handler_test.clj
+++ b/test/web_tic_tac_toe/new_game_handler_test.clj
@@ -3,7 +3,7 @@
             [cheshire.core :as cheshire]
             [web-tic-tac-toe.new-game-handler :refer :all]))
 
-(import Request)
+(import (com.omarnyte.request Request Request$Builder))
 
 (def new-game-handler (reify-handler))
 


### PR DESCRIPTION
After properly packaging the http-server artifact to clojars, I've installed `com.omarnyte.http-server` as a dependency. Thus, the program continues to work even though the nested http server source code has been deleted. 