### PR TITLE
Configure Travis CI for Clojure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: clojure
+
+dist: trusty 
+sudo: false 
+
+jdk: oraclejdk10

--- a/src/web_tic_tac_toe/game_state.clj
+++ b/src/web_tic_tac_toe/game_state.clj
@@ -7,6 +7,7 @@
 
 (import (com.omarnyte.exception BadRequestException))
 
+(def missingPlayersMessage "players key is required")
 (def missingSelectedIdxMessage "selectedIdx is required")
 (def invalidSelectedIdxMessage "Index selection is invalid")
 
@@ -50,7 +51,9 @@
 
 (defn update-players-state
   [players-state]
-  (let [current-player-mark (get players-state :currentPlayerMark)]
-    (assoc players-state 
-           :currentPlayerMark 
-           (get-opp-mark current-player-mark))))
+  (if (nil? players-state)
+      (throw (BadRequestException. missingPlayersMessage))
+      (let [current-player-mark (get players-state :currentPlayerMark)]
+        (assoc players-state 
+               :currentPlayerMark 
+               (get-opp-mark current-player-mark)))))


### PR DESCRIPTION
## `.travis.yml`
Because the Travis build environment sets the JDK to Oracle JDK 8 by default, I had to configure the Trusty Build Environment to use JDK 10. 

## `move-handler`
Prior to this PR, I had one failing test where a request to `api/move` missing the `players` key should have returned a 400 Bad Request response. Instead, it returned a 200 because the `#update-players-state` method in `game-state` did not throw a `BadRequestException` when the argument passed into it was `nil`.  